### PR TITLE
Adding the posibility of excluding dtypes.

### DIFF
--- a/recipipe/core.py
+++ b/recipipe/core.py
@@ -187,11 +187,18 @@ class RecipipeTransformer(BaseEstimator, TransformerMixin):
             exclude (:obj:`list` of :obj:`str`): List of columns to exclude.
                 The exclusion is applied after fitting the columns, so it can
                 be used at the same time as `*args` and `col_init`.
-            dtype (dtype, str, list[dtype] or list[str]): This value is passed
-                to :obj:`pandas.DataFrame.select_dtypes`. The columns returned
-                by this method (executed in the dataframe passed to the fit
-                method) will be the columns that are going to be used in the
-                transformation phase.
+            dtype (:obj:`numpy.dtype`, :obj:`str`, :obj:`list` of
+                :obj:`numpy.dtype` or with :obj:`str` or :obj:`dict`): This
+                value is passed to :obj:`pandas.DataFrame.select_dtypes`.
+                If a :obj:`dict` is given, the Pandas function is going to be
+                called with dictionary unpacking: `select_dtypes(**dtype)`.
+                In this way you can exclude, for example, int dtypes using:
+                `dtype=dict(exclude=int)`.
+                The columns returned by this method (executed in the DataFrame
+                passed to the fit method) will be the columns that are going
+                to be used in the transformation phase.
+                When used in combination with `*args` or `cols_init`, the dtype
+                filter is applied later.
             name (:obj:`str`): Human-friendly name of the transformer.
             keep_original (:obj:`bool`): `True` if you want to keep the input
                 columns used in the transformer in the transformed DataFrame,

--- a/recipipe/utils.py
+++ b/recipipe/utils.py
@@ -122,7 +122,9 @@ def fit_columns(df, cols=None, dtype=None, raise_error=True,
         if cols_fitted:
             # dtype is applied after cols.
             df = df[cols_fitted]
-        cols_fitted = list(df.select_dtypes(dtype).columns)
+        if type(dtype) != dict:
+            dtype = dict(include=dtype)
+        cols_fitted = list(df.select_dtypes(**dtype).columns)
 
     if drop_duplicates:
         cols_fitted = list(collections.OrderedDict.fromkeys(cols_fitted))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -163,12 +163,16 @@ class RecipipeTransformerTest(TestCase):
         t = RecipipeTransformerMock("c1", cols_init=["c2"])
         self.assertListEqual(t.cols_init, ["c1", "c2"])
 
-    def test_fit_cols(self):
-        """Cols should have a value after fit. """
-
+    def test_fit_cols_and_dtype(self):
         t = RecipipeTransformerMock("c*", dtype=int)
         t.fit(create_df_3dtypes())
         self.assertListEqual(t.cols, ["c1"])
+        self.assertEqual(t.n_fit, 1)
+
+    def test_fit_cols_and_dtype_exclude(self):
+        t = RecipipeTransformerMock("c*", dtype=dict(exclude=int))
+        t.fit(create_df_3dtypes())
+        self.assertListEqual(t.cols, ["c2"])
         self.assertEqual(t.n_fit, 1)
 
     def test_fit_cols_all(self):


### PR DESCRIPTION
 Allow the use of a dictionary in `dtype` to pass Pandas parameters to the `pandas.DataFrame.select_dtypes`.